### PR TITLE
Make the example more clear

### DIFF
--- a/pages/javascript/new-api/writing-a-module.md
+++ b/pages/javascript/new-api/writing-a-module.md
@@ -42,6 +42,8 @@ For this example we'll assume the file is placed at `js/WoltLabSuite/Core/Ui/Foo
 the module name is therefore `WoltLabSuite/Core/Ui/Foo`, it is automatically
 derived from the file path and name.
 
+For further instructions on how to define and require modules head over to the [RequireJS API](http://requirejs.org/docs/api.html).
+
 ```js
 define(["Ajax", "WoltLabSuite/Core/Ui/Bar"], function(Ajax, UiBar) {
   "use strict";
@@ -73,6 +75,8 @@ define(["Ajax", "WoltLabSuite/Core/Ui/Bar"], function(Ajax, UiBar) {
       };
     }
   }
+  
+  return Foo;
 });
 ```
 


### PR DESCRIPTION
I was pretty cconfused when reading this doc since the 2nd example is using `WoltLabSuite/Core/Ui/Foo` but `WoltLabSuite/Core/Ui/Foo` doesn't have an actual value.
I also never heard of require.js, so I didn't know anything about the way it works. So It'd sure be better if to refer to the RequireJS-API docs.