### PR TITLE
Changed className of DOA

### DIFF
--- a/pages/php/php_database-objects.md
+++ b/pages/php/php_database-objects.md
@@ -214,7 +214,7 @@ namespace wcf\data\example;
 use wcf\data\AbstractDatabaseObjectAction;
 
 class ExampleAction extends AbstractDatabaseObjectAction {
-    public $className = Example::class;
+    public $className = ExampleEditor::class;
 }
 ```
 


### PR DESCRIPTION
Changed $className of AbstractDatabaseObjectAction to use DatabaseObjectEditor instead of DatabaseObject. Using DatabaseObject results in the following ErrorException trying to execute actions using Ajax:
```
call_user_func() expects parameter 1 to be a valid callback, class 'newsletter\data\newsletter\Newsletter' does not have a method 'getBaseClass'
```

Using the DatabaseObjectEditor instead seems to work without any errors.

File:
```
/opt/bw-dev/lib/system/WCF.class.php (341)
```

Full Stacktrace:
```
[internal function] (?): wcf\system\WCF::handleError(…)
/opt/bw-dev/lib/data/AbstractDatabaseObjectAction.class.php (123): call_user_func(…)
/opt/bw-dev/lib/action/AJAXProxyAction.class.php (69): wcf\data\AbstractDatabaseObjectAction->__construct(…)
/opt/bw-dev/lib/action/AJAXInvokeAction.class.php (94): wcf\action\AJAXProxyAction->invoke(…)
/opt/bw-dev/lib/action/AbstractAction.class.php (47): wcf\action\AJAXInvokeAction->execute(…)
/opt/bw-dev/lib/action/AJAXInvokeAction.class.php (61): wcf\action\AbstractAction->__run(…)
/opt/bw-dev/lib/system/request/Request.class.php (83): wcf\action\AJAXInvokeAction->__run(…)
/opt/bw-dev/lib/system/request/RequestHandler.class.php (107): wcf\system\request\Request->execute(…)
/opt/bw-dev/newsletter/index.php (3): wcf\system\request\RequestHandler->handle(…)
```