### PR TITLE
Add missing events

### DIFF
--- a/pages/php/api/php_api_event_list.md
+++ b/pages/php/api/php_api_event_list.md
@@ -12,6 +12,7 @@ Events whose name is marked with an asterisk are called from a static method and
 
 | Class | Event Name |
 |-------|------------|
+| `wcf\acp\action\UserExportGdprAction` | `export` |
 | `wcf\acp\form\StyleAddForm` | `setVariables` |
 | `wcf\acp\form\UserSearchForm` | `search` |
 | `wcf\action\AbstractAction` | `checkModules` |
@@ -21,7 +22,15 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\action\AbstractAction` | `readParameters` |
 | `wcf\data\attachment\AttachmentAction` | `generateThumbnail` |
 | `wcf\data\session\SessionAction` | `keepAlive` |
+| `wcf\data\session\SessionAction` | `poll` |
+| `wcf\data\trophy\Trophy` | `renderTrophy` |
+| `wcf\data\user\online\UserOnline` | `getBrowser` |
+| `wcf\data\user\online\UserOnlineList` | `isVisible` |
+| `wcf\data\user\trophy\UserTrophy` | `getReplacements` |
+| `wcf\data\user\UserAction` | `beforeFindUsers` |
 | `wcf\data\user\UserAction` | `rename` |
+| `wcf\data\user\UserProfile` | `getAvatar` |
+| `wcf\data\user\UserProfile` | `isAccessible` |
 | `wcf\data\AbstractDatabaseObjectAction` | `finalizeAction` |
 | `wcf\data\AbstractDatabaseObjectAction` | `initializeAction` |
 | `wcf\data\AbstractDatabaseObjectAction` | `validateAction` |
@@ -50,17 +59,31 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\system\box\AbstractBoxController` | `__construct` |
 | `wcf\system\box\AbstractBoxController` | `afterLoadContent` |
 | `wcf\system\box\AbstractBoxController` | `beforeLoadContent` |
+| `wcf\system\box\AbstractDatabaseObjectListBoxController` | `afterLoadContent` |
+| `wcf\system\box\AbstractDatabaseObjectListBoxController` | `beforeLoadContent` |
+| `wcf\system\box\AbstractDatabaseObjectListBoxController` | `hasContent` |
 | `wcf\system\box\AbstractDatabaseObjectListBoxController` | `readObjects` |
 | `wcf\system\cronjob\AbstractCronjob` | `execute` |
 | `wcf\system\email\Email` | `getJobs` |
+| `wcf\system\form\builder\container\wysiwyg\WysiwygFormContainer` | `populate` |
 | `wcf\system\html\input\filter\MessageHtmlInputFilter` | `setAttributeDefinitions` |
 | `wcf\system\html\input\node\HtmlInputNodeProcessor` | `afterProcess` |
 | `wcf\system\html\input\node\HtmlInputNodeProcessor` | `beforeEmbeddedProcess` |
 | `wcf\system\html\input\node\HtmlInputNodeProcessor` | `beforeProcess` |
+| `wcf\system\html\input\node\HtmlInputNodeProcessor` | `convertPlainLinks` |
+| `wcf\system\html\input\node\HtmlInputNodeProcessor` | `getTextContent` |
 | `wcf\system\html\input\node\HtmlInputNodeProcessor` | `parseEmbeddedContent` |
 | `wcf\system\html\input\node\HtmlInputNodeWoltlabMetacodeMarker` | `filterGroups` |
+| `wcf\system\html\output\node\HtmlOutputNodePre` | `selectHighlighter` |
+| `wcf\system\html\output\node\HtmlOutputNodeProcessor` | `beforeProcess` |
+| `wcf\system\image\adapter\ImagickImageAdapter` | `getResizeFilter` |
+| `wcf\system\menu\user\profile\UserProfileMenu` | `init` |
+| `wcf\system\menu\user\profile\UserProfileMenu` | `loadCache` |
 | `wcf\system\menu\TreeMenu` | `init` |
 | `wcf\system\menu\TreeMenu` | `loadCache` |
+| `wcf\system\message\QuickReplyManager` | `addFullQuote` |
+| `wcf\system\message\QuickReplyManager` | `allowedDataParameters` |
+| `wcf\system\message\QuickReplyManager` | `beforeRenderQuote` |
 | `wcf\system\message\QuickReplyManager` | `createMessage` |
 | `wcf\system\message\QuickReplyManager` | `createdMessage` |
 | `wcf\system\message\QuickReplyManager` | `getMessage` |
@@ -71,17 +94,28 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\system\package\plugin\AbstractPackageInstallationPlugin` | `install` |
 | `wcf\system\package\plugin\AbstractPackageInstallationPlugin` | `uninstall` |
 | `wcf\system\package\plugin\AbstractPackageInstallationPlugin` | `update` |
+| `wcf\system\package\plugin\ObjectTypePackageInstallationPlugin` | `addConditionFields` |
 | `wcf\system\package\PackageInstallationDispatcher` | `postInstall` |
 | `wcf\system\package\PackageUninstallationDispatcher` | `postUninstall` |
+| `wcf\system\reaction\ReactionHandler` | `getDataAttributes` | 
 | `wcf\system\request\RouteHandler` | `didInit` | 
 | `wcf\system\session\ACPSessionFactory` | `afterInit` |
 | `wcf\system\session\ACPSessionFactory` | `beforeInit` |
 | `wcf\system\session\SessionHandler` | `afterChangeUser` |
 | `wcf\system\session\SessionHandler` | `beforeChangeUser` |
+| `wcf\system\style\StyleCompiler` | `compile` |
 | `wcf\system\template\TemplateEngine` | `afterDisplay` |
 | `wcf\system\template\TemplateEngine` | `beforeDisplay` |
+| `wcf\system\upload\DefaultUploadFileSaveStrategy` | `generateThumbnails` |
+| `wcf\system\upload\DefaultUploadFileSaveStrategy` | `save` |
 | `wcf\system\user\authentication\UserAuthenticationFactory` | `init` |
+| `wcf\system\user\notification\UserNotificationHandler` | `createdNotification` |
 | `wcf\system\user\notification\UserNotificationHandler` | `fireEvent` |
+| `wcf\system\user\notification\UserNotificationHandler` | `markAsConfirmed` |
+| `wcf\system\user\notification\UserNotificationHandler` | `markAsConfirmedByIDs` |
+| `wcf\system\user\notification\UserNotificationHandler` | `removeNotifications` |
+| `wcf\system\user\notification\UserNotificationHandler` | `updateTriggerCount` |
+| `wcf\system\user\UserBirthdayCache` | `loadMonth` |
 | `wcf\system\worker\AbstractRebuildDataWorker` | `execute` |
 | `wcf\system\CLIWCF` | `afterArgumentParsing` |
 | `wcf\system\CLIWCF` | `beforeArgumentParsing` |
@@ -92,4 +126,6 @@ Events whose name is marked with an asterisk are called from a static method and
 
 | Class | Event Name |
 |-------|------------|
+| `wbb\data\board\BoardAction` | `cloneBoard` |
+| `wbb\data\post\PostAction` | `quickReplyShouldMerge` |
 | `wbb\system\thread\ThreadHandler` | `didInit` |


### PR DESCRIPTION
There's a chance that I've missed very few events, but most should be added by this pull request.

Maybe you should enforce an (internal) policy that every newly added event **must** be added to the documentation? During plugin development I've also noticed that the documentation seems to be outdated in some other places as well, such as the PIPs. It's certainly no drama, but if you provide a public documentation, it would be desirable in the interest of the entire WoltLab community to keep this documentation up to date.