### PR TITLE
Api versions

### DIFF
--- a/pages/getting-started/getting-started_quick-start.md
+++ b/pages/getting-started/getting-started_quick-start.md
@@ -43,9 +43,6 @@ Create a new file called `package.xml` and insert the code below:
 		<author>Your Name</author>
 		<authorurl>http://www.example.com</authorurl>
 	</authorinformation>
-	<compatibility>
-		<api version="2019"/>
-	</compatibility>
 	<instructions type="install">
 		<instruction type="file" />
 		<instruction type="template" />

--- a/pages/package/package_package-xml.md
+++ b/pages/package/package_package-xml.md
@@ -160,7 +160,7 @@ The attribute `version` must be a valid version number as described in the [\<ve
 
 ### `<compatibility>`
 {% include callout.html content="Available since WoltLab Suite 3.1" type="info" %}
-{% include callout.html content="With the release of WoltLab Suite 5.2 the API versions were abolished. Instead an exclude to the version "6.0.0 Alpha 1" from the WSC is sufficient." type="warning" %}
+{% include callout.html content="With the release of WoltLab Suite 5.2 the API versions were abolished. Instead of using API versions packages should exclude version `6.0.0 Alpha 1` of `com.woltlab.wcf` going forward." type="warning" %}
 
 WoltLab Suite 3.1 introduced a new versioning system that focused around the API compatibility and is intended to replace the `<excludedpackage>` instruction for the Core for most plugins.
 

--- a/pages/package/package_package-xml.md
+++ b/pages/package/package_package-xml.md
@@ -155,8 +155,8 @@ Example:
 The attribute `version` must be a valid version number as described in the [\<version\>](#version) section. In the example above it will be impossible to install this package in WoltLab Suite Core 3.1.0 Alpha 1 or higher.
 
 ### `<compatibility>`
-
 {% include callout.html content="Available since WoltLab Suite 3.1" type="info" %}
+{% include callout.html content="With the release of WoltLab Suite 5.2 the API versions were abolished. Instead an exclude to the version "6.0.0 Alpha 1" from the WSC is sufficient." type="warning" %}
 
 WoltLab Suite 3.1 introduced a new versioning system that focused around the API compatibility and is intended to replace the `<excludedpackage>` instruction for the Core for most plugins.
 

--- a/pages/package/package_package-xml.md
+++ b/pages/package/package_package-xml.md
@@ -28,6 +28,10 @@ It provides the meta data (e.g. package name, description, author) and the instr
 	<requiredpackages>
 		<requiredpackage minversion="3.0.0">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
+	
+	<excludedpackages>
+		<excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+	</excludedpackages>
 
 	<instructions type="install">
 		<instruction type="file" />


### PR DESCRIPTION
Since the API versions are outdated, I have removed them in the "Quick Start Guide" and added a warning in the "package.xml" overview.