### PR TITLE
Clean up references to old versions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,8 +198,6 @@ Congratulations, you have just created your first package!
 
 ## Developer Tools
 
-!!! warning "This feature is available with WoltLab Suite 3.1 or newer only."
-
 The developer tools provide an interface to synchronize the data of an installed package with a bare repository on the local disk. You can re-import most PIPs at any time and have the changes applied without crafting a manual update. This process simulates a regular package update with a single PIP only, and resets the cache after the import has been completed.
 
 ### Registering a Project

--- a/docs/javascript/general-usage.md
+++ b/docs/javascript/general-usage.md
@@ -87,10 +87,8 @@ the minified and optimized file to the average visitor. You should use the
 
 !!! info "You can learn more on the [Accelerated Guest View](../migration/wsc30/javascript.md) in the migration docs."
 
-The "Accelerated Guest View" was introduced in WoltLab Suite 3.1 and aims to
-decrease page size and to improve responsiveness by enabling a read-only mode
-for visitors. If you are providing a separate compiled build for this mode, you'll
-need to include yet another switch to serve the right version to the visitor.
+The “Accelerated Guest View” aims to decrease page size and to improve responsiveness by enabling a read-only mode for visitors.
+If you are providing a separate compiled build for this mode, you'll need to include yet another switch to serve the right version to the visitor.
 
 ```html
 <script data-relocate="true" src="{@$__wcf->getPath('app')}js/App{if !ENABLE_DEBUG_MODE}{if VISITOR_USE_TINY_BUILD}.tiny{/if}.min{/if}.js?t={@LAST_UPDATE_TIME}"></script>

--- a/docs/javascript/new-api_events.md
+++ b/docs/javascript/new-api_events.md
@@ -56,9 +56,8 @@ events or trigger events itself at any time.
 
 ### Identifiying Events with the Developer Tools
 
-The Developer Tools in WoltLab Suite 3.1 offer an easy option to identify existing
-events that are fired while code is being executed. You can enable this watch
-mode through your browser's console using `Devtools.toggleEventLogging()`:
+The Developer Tools offer an easy option to identify existing events that are fired while code is being executed.
+You can enable this watch mode through your browser's console using `Devtools.toggleEventLogging()`:
 
 ```
 > Devtools.toggleEventLogging();

--- a/docs/package/database-php-api.md
+++ b/docs/package/database-php-api.md
@@ -1,7 +1,5 @@
 # Database PHP API
 
-!!! info "Available since WoltLab Suite 5.2."
-
 While the [sql](pip/sql.md) package installation plugin supports adding and removing tables, columns, and indices, it is not able to handle cases where the added table, column, or index already exist.
 We have added a new PHP-based API to manipulate the database scheme which can be used in combination with the [script](pip/script.md) package installation plugin that skips parts that already exist:
 

--- a/docs/package/pip/media-provider.md
+++ b/docs/package/pip/media-provider.md
@@ -1,7 +1,5 @@
 # Media Provider Package Installation Plugin
 
-!!! info "Available since WoltLab Suite 3.1"
-
 Media providers are responsible to detect and convert links to a 3rd party service inside messages.
 
 ## Components

--- a/docs/php/api/form_builder/overview.md
+++ b/docs/php/api/form_builder/overview.md
@@ -1,22 +1,10 @@
 # Form Builder
 
-!!! info "Form builder is only available since WoltLab Suite Core 5.2."
+WoltLab Suite includes a powerful way of creating forms: Form Builder.
+Form builder allows you to easily define all the fields and their constraints and interdependencies within PHP with full IDE support.
+It will then automatically generate the necessary HTML with full interactivity to render all the fields and also validate the fields’ contents upon submission.
 
 !!! info "The [migration guide for WoltLab Suite Core 5.2](../../../migration/wsc31/form-builder.md) provides some examples of how to migrate existing forms to form builder that can also help in understanding form builder if the old way of creating forms is familiar."
-
-
-## Advantages of Form Builder
-
-WoltLab Suite 5.2 introduces a new powerful way of creating forms: form builder.
-Before taking a closer look at form builder, let us recap how forms are created in previous versions:
-In general, for each form field, there is a corresponding property of the form's PHP class whose value has to be read from the request data, validated, and passed to the database object action to store the value in a database table.
-When editing an object, the property's value has to be set using the value of the corresponding property of the edited object.
-In the form's template, you have to write the `<form>` element with all of its children: the `<section>` elements, the `<dl>` elements, and, of course, the form fields themselves.
-In summary, this way of creating forms creates much duplicate or at least very similar code and makes it very time consuming if the structure of forms in general or a specific type of form field has to be changed.
-
-Form builder, in contrast, relies on PHP objects representing each component of the form, from the form itself down to each form field.
-This approach makes creating forms as easy as creating some PHP objects, populating them with all the relevant data, and one line of code in the template to print the form.
-
 
 ## Form Builder Components
 

--- a/docs/php/api/sitemaps.md
+++ b/docs/php/api/sitemaps.md
@@ -1,8 +1,6 @@
 # Sitemaps
 
-!!! warning "This feature is available with WoltLab Suite 3.1 or newer only."
-
-Since version 3.1, WoltLab Suite Core is capable of automatically creating a sitemap.
+WoltLab Suite is capable of automatically creating a sitemap.
 This sitemap contains all static pages registered via the page package installation plugin and which may be indexed by search engines (checking the `allowSpidersToIndex` parameter and page permissions) and do not expect an object ID.
 Other pages have to be added to the sitemap as a separate object.
 

--- a/docs/php/gdpr.md
+++ b/docs/php/gdpr.md
@@ -12,9 +12,7 @@ on woltlab.com.
 
 ## Including Data in the Export
 
-The `wcf\acp\action\UserExportGdprAction` introduced with WoltLab Suite 3.1.3
-already includes the Core itself as well as all official apps, but you'll need to
-include any personal data stored for your plugin or app by yourself.
+The `wcf\acp\action\UserExportGdprAction` already includes WoltLab Suite Core itself as well as all official apps, but you'll need to include any personal data stored for your plugin or app by yourself.
 
 The event `export` is fired before any data is sent out, but after any Core data
 has been dumped to the `$data` property.


### PR DESCRIPTION
- Remove references to old WoltLab Suite versions
- Rewrite form builder introduction
