### PR TITLE
Add missing PHP-API events

### DIFF
--- a/docs/php/api/event_list.md
+++ b/docs/php/api/event_list.md
@@ -131,6 +131,13 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\data\conversation\ConversationAction` | `addParticipants_validateParticipants` |
 | `wcf\data\conversation\message\ConversationMessageAction` | `afterQuickReply` |
 
+## WoltLab Suite Core: Infractions
+
+| Class | Event Name |
+|-------|------------|
+| `wcf\system\infraction\suspension\BanSuspensionAction` | `suspend` |
+| `wcf\system\infraction\suspension\BanSuspensionAction` | `unsuspend` |
+
 ## WoltLab Suite Forum
 
 | Class | Event Name |

--- a/docs/php/api/event_list.md
+++ b/docs/php/api/event_list.md
@@ -20,6 +20,7 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\data\trophy\Trophy` | `renderTrophy` |
 | `wcf\data\user\online\UserOnline` | `getBrowser` |
 | `wcf\data\user\online\UserOnlineList` | `isVisible` |
+| `wcf\data\user\online\UserOnlineList` | `isVisibleUser` |
 | `wcf\data\user\trophy\UserTrophy` | `getReplacements` |
 | `wcf\data\user\UserAction` | `beforeFindUsers` |
 | `wcf\data\user\UserAction` | `rename` |
@@ -34,6 +35,8 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\form\AbstractForm` | `saved` |
 | `wcf\form\AbstractForm` | `submit` |
 | `wcf\form\AbstractForm` | `validate` |
+| `wcf\form\AbstractFormBuilderForm` | `createForm` |
+| `wcf\form\AbstractFormBuilderForm` | `buildForm` |
 | `wcf\form\AbstractModerationForm` | `prepareSave` |
 | `wcf\page\AbstractPage` | `assignVariables` |
 | `wcf\page\AbstractPage` | `checkModules` |
@@ -42,6 +45,8 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\page\AbstractPage` | `readParameters` |
 | `wcf\page\AbstractPage` | `show` |
 | `wcf\page\MultipleLinkPage` | `beforeReadObjects` |
+| `wcf\page\MultipleLinkPage` | `insteadOfReadObjects` |
+| `wcf\page\MultipleLinkPage` | `afterInitObjectList` |
 | `wcf\page\MultipleLinkPage` | `calculateNumberOfPages` |
 | `wcf\page\MultipleLinkPage` | `countItems` |
 | `wcf\page\SortablePage` | `validateSortField` |
@@ -50,6 +55,7 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\system\bbcode\MessageParser` | `beforeParsing` |
 | `wcf\system\bbcode\SimpleMessageParser` | `afterParsing` |
 | `wcf\system\bbcode\SimpleMessageParser` | `beforeParsing` |
+| `wcf\system\box\BoxHandler` | `loadBoxes` |
 | `wcf\system\box\AbstractBoxController` | `__construct` |
 | `wcf\system\box\AbstractBoxController` | `afterLoadContent` |
 | `wcf\system\box\AbstractBoxController` | `beforeLoadContent` |
@@ -82,6 +88,8 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\system\message\QuickReplyManager` | `createdMessage` |
 | `wcf\system\message\QuickReplyManager` | `getMessage` |
 | `wcf\system\message\QuickReplyManager` | `validateParameters` |
+| `wcf\system\message\quote\MessageQuoteManager` | `addFullQuote` |
+| `wcf\system\message\quote\MessageQuoteManager` | `beforeRenderQuote` |
 | `wcf\system\option\OptionHandler` | `afterReadCache` |
 | `wcf\system\package\plugin\AbstractPackageInstallationPlugin` | `construct` |
 | `wcf\system\package\plugin\AbstractPackageInstallationPlugin` | `hasUninstall` |

--- a/docs/php/api/event_list.md
+++ b/docs/php/api/event_list.md
@@ -124,6 +124,13 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\system\WCF` | `initialized` |
 | `wcf\util\HeaderUtil` | `parseOutput`*|
 
+## WoltLab Suite Core: Conversations
+
+| Class | Event Name |
+|-------|------------|
+| `wcf\data\conversation\ConversationAction` | `addParticipants_validateParticipants` |
+| `wcf\data\conversation\message\ConversationMessageAction` | `afterQuickReply` |
+
 ## WoltLab Suite Forum
 
 | Class | Event Name |

--- a/docs/php/api/event_list.md
+++ b/docs/php/api/event_list.md
@@ -145,3 +145,10 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wbb\data\board\BoardAction` | `cloneBoard` |
 | `wbb\data\post\PostAction` | `quickReplyShouldMerge` |
 | `wbb\system\thread\ThreadHandler` | `didInit` |
+
+## WoltLab Suite Filebase
+
+| Class | Event Name |
+|-------|------------|
+| `filebase\data\file\File` | `getPrice` |
+| `filebase\data\file\ViewableFile` | `getUnreadFiles` |

--- a/docs/php/api/event_list.md
+++ b/docs/php/api/event_list.md
@@ -19,8 +19,8 @@ Events whose name is marked with an asterisk are called from a static method and
 | `wcf\data\session\SessionAction` | `poll` |
 | `wcf\data\trophy\Trophy` | `renderTrophy` |
 | `wcf\data\user\online\UserOnline` | `getBrowser` |
-| `wcf\data\user\online\UserOnlineList` | `isVisible` |
-| `wcf\data\user\online\UserOnlineList` | `isVisibleUser` |
+| `wcf\data\user\online\UsersOnlineList` | `isVisible` |
+| `wcf\data\user\online\UsersOnlineList` | `isVisibleUser` |
 | `wcf\data\user\trophy\UserTrophy` | `getReplacements` |
 | `wcf\data\user\UserAction` | `beforeFindUsers` |
 | `wcf\data\user\UserAction` | `rename` |


### PR DESCRIPTION
Closes https://github.com/WoltLab/docs.woltlab.com/issues/301

I took the liberty of adding a few more missing events, including those from the conversations and infractions plugins, as well as the filebase. I've split the changes into multiple commits, so you may choose which ones to apply if not all.

I've added `wcf\data\user\online\UsersOnlineList` -> `isVisibleUser` which kind of replaces `isVisible`, but I don't know if you plan on renaming it to `isVisible` when removing `UsersOnlineList::isVisible()` , which is deprecated since 5.3.

I've not added `wcf\acp\form\DevtoolsProjectPipEntryAddForm` -> `addPipFormFields` as I didn't find it necessary, but I'm happy to add it as well while the PR is open anyway.

I haven't checked 5.3 explicitly, but all events should be available at least as of 5.4.