### PR TITLE
Remove explanation on how to access superglobals via templates

### DIFF
--- a/docs/migration/wsc55/deprecations_removals.md
+++ b/docs/migration/wsc55/deprecations_removals.md
@@ -259,6 +259,12 @@ With version 6.0, we have deprecated certain components and removed several othe
 
 - `$__sessionKeepAlive` ([WoltLab/WCF#5055](https://github.com/WoltLab/WCF/pull/5055))
 - `$__wcfVersion` ([WoltLab/WCF#4927](https://github.com/WoltLab/WCF/pull/4927))
+- `$tpl.cookie` ([WoltLab/WCF@7cfd5578ede22e](https://github.com/WoltLab/WCF/commit/7cfd5578ede22e798b770262c0cdf1e9dfe25d36))
+- `$tpl.env` ([WoltLab/WCF@7cfd5578ede22e](https://github.com/WoltLab/WCF/commit/7cfd5578ede22e798b770262c0cdf1e9dfe25d36))
+- `$tpl.get` ([WoltLab/WCF@7cfd5578ede22e](https://github.com/WoltLab/WCF/commit/7cfd5578ede22e798b770262c0cdf1e9dfe25d36))
+- `$tpl.now` ([WoltLab/WCF@7cfd5578ede22e](https://github.com/WoltLab/WCF/commit/7cfd5578ede22e798b770262c0cdf1e9dfe25d36))
+- `$tpl.post` ([WoltLab/WCF@7cfd5578ede22e](https://github.com/WoltLab/WCF/commit/7cfd5578ede22e798b770262c0cdf1e9dfe25d36))
+- `$tpl.server` ([WoltLab/WCF@7cfd5578ede22e](https://github.com/WoltLab/WCF/commit/7cfd5578ede22e798b770262c0cdf1e9dfe25d36))
 
 ### Miscellaneous
 

--- a/docs/view/templates.md
+++ b/docs/view/templates.md
@@ -197,17 +197,6 @@ If you want to call a function on a variable, you can use the modifier syntax:
 
 #### System Template Variable
 
-The template variable `$tpl` is automatically assigned and is an array containing different data:
-
-- `$tpl[get]` contains `$_GET`.
-- `$tpl[post]` contains `$_POST`.
-- `$tpl[cookie]` contains `$_COOKIE`.
-- `$tpl[server]` contains `$_SERVER`.
-- `$tpl[env]` contains `$_ENV`.
-- `$tpl[now]` contains `TIME_NOW` (current timestamp).
-
-Furthermore, the following template variables are also automatically assigned:
-
 - `$__wcf` contains the `WCF` object (or `WCFACP` object in the backend).
 
 ### Comments


### PR DESCRIPTION
One really really shouldn't do this.
