### PR TITLE
Fix global.d.ts file path

### DIFF
--- a/snippets/typescript/tsconfig.json
+++ b/snippets/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "node_modules/@woltlab/wcf/global.d.ts",
+    "node_modules/@woltlab/wcf/ts/global.d.ts",
     "ts/**/*"
   ],
   "compilerOptions": {


### PR DESCRIPTION
As explained in #358 the path of the global.d.ts in the tsconfig.json is wrong. I have added the missing ts folder to the path