### PR TITLE
Update package.xml documentation

### DIFF
--- a/docs/package/package-xml.md
+++ b/docs/package/package-xml.md
@@ -70,6 +70,12 @@ Invalid examples:
 
 Must be a valid [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) date, e.g. `2013-12-27`.
 
+#### `<packageurl>`
+
+> (optional)
+
+URL to the package website that provides detailed information about the package.
+
 ### `<authorinformation>`
 
 Holds meta data regarding the package's author.

--- a/docs/package/package-xml.md
+++ b/docs/package/package-xml.md
@@ -76,6 +76,13 @@ Must be a valid [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) date, e.g. `20
 
 URL to the package website that provides detailed information about the package.
 
+#### `<license>`
+
+> (optional)
+
+Name of a generic license type or URL to a custom license.
+The attribute `language` can also be used here, please reference to [`<packagename>`](#packageName) for details.
+
 ### `<authorinformation>`
 
 Holds meta data regarding the package's author.

--- a/docs/package/package-xml.md
+++ b/docs/package/package-xml.md
@@ -31,19 +31,19 @@ Holds the entire meta data of the package.
 #### `<packagename>`
 
 This is the actual package name displayed to the end user, this can be anything you want, try to keep it short.
-It supports the attribute `languagecode` which allows you to provide the package name in different languages, please be aware that if it is not present, `en` (English) is assumed:
+It supports the attribute `language` which allows you to provide the package name in different languages, please be aware that if it is not present, `en` (English) is assumed:
 
 ```xml
 <packageinformation>
 	<packagename>Simple Package</packagename>
-	<packagename languagecode="de">Einfaches Paket</packagename>
+	<packagename language="de">Einfaches Paket</packagename>
 </packageinformation>
 ```
 
 #### `<packagedescription>`
 
 Brief summary of the package, use it to explain what it does since the package name might not always be clear enough.
-The attribute `languagecode` is available here too, please reference to [`<packagename>`](#packageName) for details.
+The attribute `language` can also be used here, please reference to [`<packagename>`](#packageName) for details.
 
 #### `<version>`
 


### PR DESCRIPTION
Closes https://github.com/WoltLab/docs.woltlab.com/issues/363 and https://github.com/WoltLab/docs.woltlab.com/issues/364 and may be brought to 5.4 and 5.5 aswell. Since 5.3 is basically EOL, it can probably be ignored.